### PR TITLE
Clarification on omitting types

### DIFF
--- a/chapters/Basics.md
+++ b/chapters/Basics.md
@@ -317,7 +317,12 @@ let foo = "hello there!";
 ```
 
 Even though we didn't tell TypeScript that `foo` had the type `string` it was able to figure that out.
-That's a feature, and it's best not to add annotations when the type system would end up inferring the same type anyway.
+That's a feature, and it's often preferred not to add annotations when the type system would end up inferring the same type anyway.
+For example, using `Date()` without `new` could be a typo as above, but here we are explicitly saying that we expect a string:
+
+```ts
+let now: string = Date();
+```
 
 ## Erased Types
 


### PR DESCRIPTION
There are two big reasons not to omit types:

* In a type system with subtypes there is a choice that people can
  specify, unlike a traditional typechecker (like ML) where there is
  always just one correct type.

* Even in ML, if you follow the popular habit of dropping all types
  except for the interface types, you might be dealing with complicated
  code where a type error would make the typechecker infer the wrong
  types, ending up with a huge type error which is almost completely
  useless.

In addition, the `Date()` example shows another case for explicit types:
what if *I* know that it returns a string, but others won't and I want
to be explicit about wanting a string?  Adding a `: string` would be
good in this case.

So, I changed "best" to "often preferred", and added the last thing as
an example.  (Demonstrating the two points would be more verbose, so not
done.)