### PR TITLE
Remove unused type from narrowing example

### DIFF
--- a/reference/Widening-and-Narrowing.md
+++ b/reference/Widening-and-Narrowing.md
@@ -202,7 +202,6 @@ Narrowing mostly commonly removes all but one type from a union, but
 doesn't necessarily need to:
 
 ```ts
-type Type = Anonymous | Class | Interface
 function f(thing: string | number | boolean | object) {
   if (typeof thing === 'string' || typeof thing === 'number') {
     return lookup[thing];


### PR DESCRIPTION
An example for type narrowing included the line `type Type = Anonymous | Class | Interface`, but it wasn't used in the example, or referenced outside of it.