### PR TITLE
Grammar fix

### DIFF
--- a/chapters/Types from Extraction.md
+++ b/chapters/Types from Extraction.md
@@ -72,7 +72,7 @@ let x : msgbox("Are you sure you want to continue?");
 
 ## The `keyof` type operator {#keyof}
 
-The `keyof` operator takes a type and produces a string or numeric literal union of its keys:
+The `keyof` operator takes an object type and produces a string or numeric literal union of its keys:
 
 ```ts
 type Point = { x: number, y: number };


### PR DESCRIPTION
I presume only object types have keys? Correct me if I'm wrong. Still it would make sense to clarify what type is meant, because it wouldn't make sense to use it with any basic type, right?